### PR TITLE
Fix "Mobile Speed Matters" URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A new standards effort for collaborating on high-level features.
 
 The [Extensible Web Manifesto](https://extensiblewebmanifesto.org/)’s focus on low-level primitives promotes a healthy, well-layered platform that encourages innovation and experimentation in JavaScript. But focusing on low-level primitives means that developers must build most application-level components on their own, creating a high barrier to entry for new web developers.
 
-This lack of built-in high-level features also bloats page load size. The average site payload is [2.5 MB and takes 19 seconds to load](https://www.doubleclickbygoogle.com/articles/mobile-speed-matters/).
+This lack of built-in high-level features also bloats page load size. The average site payload is [2.5 MB and takes 19 seconds to load](https://www.thinkwithgoogle.com/intl/en-154/marketing-collections/mobile/mobile-speed-matters/).
 
 Historically, standards bodies and implementers have been reluctant to work on higher-level APIs. In particular, introducing new capabilities via high-level APIs is dangerous, as when we get something wrong, developers are often left with no other way to access these capabilities. Shipping features also incurs an ongoing maintenance and runtime cost — every new feature pollutes the browser namespace, increases JS startup costs, and represents a new surface to introduce bugs throughout the codebase.
 


### PR DESCRIPTION
The previous URL was broken and redirecting to a Google Marketing website. This was the only other page from Google I could find with the same title